### PR TITLE
removed warnings and added cookie options

### DIFF
--- a/src/Klimesf/Security/JWTUserStorage.php
+++ b/src/Klimesf/Security/JWTUserStorage.php
@@ -60,7 +60,7 @@ class JWTUserStorage implements IUserStorage
 	/**
 	 * @var array
 	 */
-	private $jwtData;
+	private $jwtData = array();
 
 	/**
 	 * @var string
@@ -168,6 +168,9 @@ class JWTUserStorage implements IUserStorage
 	function getIdentity()
 	{
 		$this->loadJWTCookie();
+		if (empty($this->jwtData)) {
+			return null;
+		}
 		return $this->identitySerializer->deserialize($this->jwtData);
 	}
 
@@ -226,28 +229,23 @@ class JWTUserStorage implements IUserStorage
 
 	/**
 	 * Loads JWT from HTTP cookie and stores the data into the $jwtData variable.
-	 * @return array|bool The JWT data as array or FALSE if there is no JWT cookie.
 	 */
 	private function loadJWTCookie()
 	{
 		if ($this->cookieSaved) {
-			return true;
+			return;
 		}
 
 		$jwtCookie = $this->request->getCookie(self::COOKIE_NAME);
 		if (!$jwtCookie) {
 			$this->logoutReason = self::INACTIVITY | self::BROWSER_CLOSED;
-			return false;
+			return;
 		}
 
 		try {
 			$this->jwtData = (array) $this->jwtService->decode($jwtCookie, $this->privateKey, [$this->algorithm]);
-
 		} catch (ExpiredException $e) {
 			$this->logoutReason = self::INACTIVITY;
-			return false;
 		}
-
-		return $this->jwtData;
 	}
 }

--- a/src/Klimesf/Security/JWTUserStorage.php
+++ b/src/Klimesf/Security/JWTUserStorage.php
@@ -136,7 +136,7 @@ class JWTUserStorage implements IUserStorage
 		$cookieSecure = null,
 		$cookieHttpOnly = null,
 		$cookieName = null
-    ) {
+	) {
 		$this->privateKey = $privateKey;
 		$this->algorithm = $algorithm;
 		$this->request = $request;

--- a/src/Klimesf/Security/JWTUserStorage.php
+++ b/src/Klimesf/Security/JWTUserStorage.php
@@ -124,10 +124,19 @@ class JWTUserStorage implements IUserStorage
 	 * @param bool                 $cookieHttpOnly
 	 * @param string               $cookieName
 	 */
-	public function __construct($privateKey, $algorithm, IRequest $request,
-                                IResponse $response, IJsonWebTokenService $jsonWebTokenService,
-                                IIdentitySerializer $identitySerializer, $cookiePath = null, $cookieDomain = null, $cookieSecure = null, $cookieHttpOnly = null, $cookieName = null)
-	{
+	public function __construct(
+		$privateKey,
+		$algorithm,
+		IRequest $request,
+		IResponse $response,
+		IJsonWebTokenService $jsonWebTokenService,
+		IIdentitySerializer $identitySerializer,
+		$cookiePath = null,
+		$cookieDomain = null,
+		$cookieSecure = null,
+		$cookieHttpOnly = null,
+		$cookieName = null
+    ) {
 		$this->privateKey = $privateKey;
 		$this->algorithm = $algorithm;
 		$this->request = $request;


### PR DESCRIPTION
1) removed warnings when accessing jwtData as array when it's not. 
2) removed meaningless call to deserialize when there is no cookie. 
3) removed meaningless returns of loadJWTCookie that are never checked anyway.

It should be obvious which parts of the commit refer to which of the three removals.
I think that all should be accepted, but at least the 1) should definitely be accepted, even if only itself alone. Otherwise it is causing Nette to display error trace in development mode thoughout the whole project, which is pretty annoying. In production the warnings are ignored and the overall behaviour is as expected. So this is merely for-development-convenience change. But on the other hand, having warnings in production code is probably not ok on its own.


In the later commit there is added support for setting config options accepted by IResponse::setCookie.
Also the dependencies on Reponse and Request are generalized to IResponse and IRequest interfaces.